### PR TITLE
Refactoring: avoid allocating POS filters for every function call

### DIFF
--- a/pkg/infrastructure/tokenizer/eng/en_prose_tokenizer.go
+++ b/pkg/infrastructure/tokenizer/eng/en_prose_tokenizer.go
@@ -14,6 +14,10 @@ import (
 
 type EnProseTokenizer struct{}
 
+var enIndexableTokenPOSPrefix = []string{
+	"JJ", "MD", "NN", "PDT", "PRP", "RB", "RPP", "UH", "VB", "WP", "WRB",
+}
+
 func NewEnProseTokenizer() service.Tokenizer {
 	return &EnProseTokenizer{}
 }
@@ -23,13 +27,10 @@ func (tokenizer *EnProseTokenizer) Tokenize(ctx context.Context, content string)
 	if err != nil {
 		return nil, errors.NewError(code.Unknown, err)
 	}
-	EnIndexableTokenPOSPrefix := []string{
-		"JJ", "MD", "NN", "PDT", "PRP", "RB", "RPP", "UH", "VB", "WP", "WRB",
-	}
 	terms := []entities.TermCreate{}
 	for _, token := range doc.Tokens() {
 		indexableToken := false
-		for _, prefix := range EnIndexableTokenPOSPrefix {
+		for _, prefix := range enIndexableTokenPOSPrefix {
 			if strings.HasPrefix(token.Tag, prefix) {
 				indexableToken = true
 			}

--- a/pkg/infrastructure/tokenizer/ja/ja_kagome_tokenizer.go
+++ b/pkg/infrastructure/tokenizer/ja/ja_kagome_tokenizer.go
@@ -7,8 +7,17 @@ import (
 	"github.com/YadaYuki/omochi/pkg/domain/service"
 	"github.com/YadaYuki/omochi/pkg/errors"
 	"github.com/ikawaha/kagome-dict/ipa"
+	"github.com/ikawaha/kagome/v2/filter"
 	"github.com/ikawaha/kagome/v2/tokenizer"
 )
+
+var indexable = filter.NewPOSFilter([]filter.POS{
+	{"感動詞"},
+	{"形容詞"},
+	{"動詞"},
+	{"名詞"},
+	{"副詞"},
+}...)
 
 type JaKagomeTokenizer struct {
 	t *tokenizer.Tokenizer
@@ -24,11 +33,9 @@ func NewJaKagomeTokenizer() service.Tokenizer {
 
 func (tokenizer *JaKagomeTokenizer) Tokenize(ctx context.Context, japaneseContent string) (*[]entities.TermCreate, *errors.Error) {
 	tokens := tokenizer.t.Tokenize(japaneseContent)
-	var JaIndexableTokenPOS map[string]bool = map[string]bool{"感動詞": true, "形容詞": true, "動詞": true, "名詞": true, "副詞": true}
-	terms := []entities.TermCreate{}
+	var terms []entities.TermCreate
 	for _, token := range tokens {
-		POS := token.Features()[0]
-		if _, ok := JaIndexableTokenPOS[POS]; ok {
+		if indexable.Match(token.POS()) {
 			terms = append(terms, *entities.NewTermCreate(token.Surface, nil))
 		}
 	}


### PR DESCRIPTION
The following two minor fixes:

* POS filters were moved out of the tokenize function, since they were reserved for each function call,
* Refactored the Japanese POS filter.